### PR TITLE
create simple ping server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ RUN dart pub get --offline
 # COPY --from=build /app/bin/dart_runner_bot /app/bin/
 
 # CMD [ "/app/bin/dart_runner_bot" ]
-
+EXPOSE 8080
 CMD [ "dart", "bin/dart_runner_bot.dart" ]

--- a/bin/dart_runner_bot.dart
+++ b/bin/dart_runner_bot.dart
@@ -1,10 +1,41 @@
+import 'dart:io';
+
 import 'package:dart_runner_bot/events/client_event.dart';
 import 'package:dart_runner_bot/events/interaction_event.dart';
 import 'package:dart_runner_bot/services/env_loader.dart';
 import 'package:dart_runner_bot/services/logger.dart';
 import 'package:nyxx/nyxx.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_router/shelf_router.dart' as shelf_router;
+
+Response _helloWorldHandler(Request request) =>
+    Response.ok('Dart Runner Bot bot is up and wonderful!');
 
 void main(List<String> arguments) async {
+  final router = shelf_router.Router()..get('/ping', _helloWorldHandler);
+
+  // If the "PORT" environment variable is set, listen to it. Otherwise, 8080.
+  // https://cloud.google.com/run/docs/reference/container-contract#port
+  final port = int.parse(Platform.environment['PORT'] ?? '8080');
+
+  // See https://pub.dev/documentation/shelf/latest/shelf/Cascade-class.html
+  final cascade = Cascade()
+      // If a corresponding file is not found, send requests to a `Router`
+      .add(router);
+
+  // See https://pub.dev/documentation/shelf/latest/shelf_io/serve.html
+  final server = await shelf_io.serve(
+    // See https://pub.dev/documentation/shelf/latest/shelf/logRequests.html
+    logRequests()
+        // See https://pub.dev/documentation/shelf/latest/shelf/MiddlewareExtensions/addHandler.html
+        .addHandler(cascade.handler),
+    InternetAddress.anyIPv4, // Allows external connections
+    port,
+  );
+
+  print('Serving at http://${server.address.host}:${server.port}');
+
   try {
     // Create new bot instance
     final INyxxWebsocket botClient =

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.5"
+  http_methods:
+    dependency: transitive
+    description:
+      name: http_methods
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -247,7 +254,7 @@ packages:
     source: hosted
     version: "2.3.1"
   shelf:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shelf
       url: "https://pub.dartlang.org"
@@ -260,6 +267,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  shelf_router:
+    dependency: "direct main"
+    description:
+      name: shelf_router
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.3"
   shelf_static:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   nyxx: ^4.0.0
   nyxx_commands: ^4.3.0
   nyxx_interactions: ^4.3.1
+  shelf: ^1.3.2
+  shelf_router: ^1.1.3
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Started an HTTP server that listens to a simple GET request corresponding to ping functionality, to ensure that the bot maintains active/up time in selected Hosting providers.

The URL can now be pinged using any auto-pinger bot service at regular intervals to do so.